### PR TITLE
Added discovery of Printers via lpinfo , PAPPL and Printer Applications

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,7 @@ gio_unix2_dep = dependency ('gio-unix-2.0', version : glib2_req)
 gobject2_dep = dependency ('gobject-2.0', version : glib2_req)
 polkit_dep = dependency ('polkit-gobject-1', version : '>= 0.97')
 cups_dep = dependency ('cups', version : '>= 1.6')
+pappl_dep = dependency ('pappl', version : '>=1.0')
 
 subdir ('po')
 subdir ('src')

--- a/src/cups.c
+++ b/src/cups.c
@@ -1516,12 +1516,20 @@ FILE* DeviceList(CphCups  *cups,
     return fp;
 }
 
+static void 
+_cph_cups_pappl_device_err_cb(const char *message, CphCups *cups)
+{        _cph_cups_set_internal_status( cups, 
+                          g_strdup_printf("%s",message));
+        return;
+}
+
 static bool
 _cph_cups_pappl_device_cb(const char *device_info,const char *device_uri,const char *device_id,void *data)
 {
+        (void)data;
     _cph_cups_get_devices_cb( false, NULL, device_id, device_info, NULL, device_uri, NULL, NULL);
    
-   return true;
+   return (false);
 }
 
 int _parse_app_devices( CphCups *cups,
@@ -1537,22 +1545,7 @@ int _parse_app_devices( CphCups *cups,
 
 	         strcpy(device_uri,buf);
 
-                 device_uri[strlen(device_uri) - 1] = '\0';
-                //  pappl_device_t	  *device;		
-                //  if ((device = papplDeviceOpen(device_uri, "get-id", NULL, NULL)) == NULL)
-                //      {   
-                //         _cph_cups_set_internal_status(cups,
-                //          g_strdup_printf("Cannot get Device '%s'.",device_uri));
-                //         return (1);
-                //      }
-                // if ((papplDeviceGetID(device, device_id, sizeof(device_id))) == NULL)
-                //   { 
-                //         _cph_cups_set_internal_status(cups,
-                //          g_strdup_printf("No device ID for '%s'",device_uri));
-                //   }
-                
-                // papplDeviceClose(device);
-                
+                 device_uri[strlen(device_uri) - 1] = '\0';                
                 _cph_cups_get_devices_cb( true, NULL, device_id, NULL, NULL, device_uri, NULL, NULL);
           }
 
@@ -1671,11 +1664,10 @@ _cph_cups_devices_get (CphCups           *cups,
         //                          _cph_cups_get_devices_cb,
         //                          data);
         
-        // Printer apps 
+        // Printer apps      
         char *app[] = {   
-                       "hplip",
+                       "hplip",                  // TO DO - Discovery of Printer Applications
                        "hp",
-                       "LPrint",
                        "gutenprint",
                	       "ps",
                        "ghostscript"
@@ -1718,13 +1710,12 @@ _cph_cups_devices_get (CphCups           *cups,
              g_free(cmd);
 	  }
 
-        /*  pappl_device_cb_t callback = &_cph_cups_pappl_device_cb; 
-        //  papplDeviceList( PAPPL_DEVTYPE_ALL,
-        //                   callback,                  
-        //                   data,
-        //                   NULL,
-                      NULL );
-        */    
+         papplDeviceList( PAPPL_DEVTYPE_ALL,
+                          _cph_cups_pappl_device_cb,                  
+                          NULL,
+                          _cph_cups_pappl_device_err_cb,
+                          cups );
+           
 		
         g_free (include_schemes_param);
         g_free (exclude_schemes_param);

--- a/src/meson.build
+++ b/src/meson.build
@@ -24,7 +24,7 @@ executable (
   cph_iface_mechanism_source,
   install: true,
   install_dir: join_paths (prefix, libexecdir),
-  dependencies : [glib2_dep, gio2_dep, gio_unix2_dep, polkit_dep, cups_dep]
+  dependencies : [glib2_dep, gio2_dep, gio_unix2_dep, polkit_dep, cups_dep, pappl_dep]
 )
 
 
@@ -43,7 +43,7 @@ foreach test_name: tests
     test_name + '.c',
     cph_sources,
     cph_iface_mechanism_source,
-    dependencies: [glib2_dep, gobject2_dep, gio2_dep, gio_unix2_dep, cups_dep],
+    dependencies: [glib2_dep, gobject2_dep, gio2_dep, gio_unix2_dep, cups_dep, pappl_dep],
     c_args: ['-DG_DISABLE_DEPRECATED'])
   test (test_name, bin,
         env: ['G_TEST_SRCDIR=@0@'.format (meson.current_source_dir ()),


### PR DESCRIPTION
This commit includes the deprecation of existing call of `cupsGetDevices()` and replacing it with `lpinfo`, `papplDeviceList`, and `printer-app devices` for the discovery of printer devices. The work for discovery of printer application is also complete and I will be adding it in this commit as well.